### PR TITLE
fix: support media queries and process child css of media query

### DIFF
--- a/polyfill-svg-uri.js
+++ b/polyfill-svg-uri.js
@@ -63,7 +63,13 @@ function polyfillSvgUri() {
   list2array(document.styleSheets).forEach(function(styleSheet) {
     try {
       list2array(styleSheet.cssRules).forEach(function(cssRule) {
-        parseStyle(cssRule.style);
+        if (cssRule.type === 4) {
+          list2array(cssRule.cssRules).forEach(function(mediaCssRule) {
+            parseStyle(mediaCssRule.style);
+          });
+        } else {
+          if (cssRule.style) parseStyle(cssRule.style);
+        }
       });
     } catch (e) {
       global.console.warn('Couldn\'t get cssRules.', e, styleSheet);

--- a/polyfill-svg-uri.js
+++ b/polyfill-svg-uri.js
@@ -65,10 +65,12 @@ function polyfillSvgUri() {
       list2array(styleSheet.cssRules).forEach(function(cssRule) {
         if (cssRule.type === 4) {
           list2array(cssRule.cssRules).forEach(function(mediaCssRule) {
-            parseStyle(mediaCssRule.style);
+            if (mediaCssRule.type === 1 && mediaCssRule.style) {
+              parseStyle(mediaCssRule.style);
+            }
           });
-        } else {
-          if (cssRule.style) parseStyle(cssRule.style);
+        } else if (cssRule.type === 1 && cssRule.style) {
+          parseStyle(cssRule.style);
         }
       });
     } catch (e) {


### PR DESCRIPTION
When using media queries in css the polyfill throws an error in IE11:  

Couldn't get cssRules. TypeError: Unable to get property 'length' of undefined or null reference [object CSSStyleSheet]

``` css
.fail {
    background-image: url("data:image/svg+xml;utf8,<svg width='40px' height='40px' viewBox='0 0 40 40' version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink'></svg>");
}

@media all and (min-width: 481px) and (max-width: 768px) {

    .fail {
        background-image: url("data:image/svg+xml;utf8,<svg width='40px' height='40px' viewBox='0 0 40 40' version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink'></svg>");
    }
}
```

Svg image is simplified/content removed for readability.

This fixes it, and processes the child css rules of the media query.

Also added a check for undefined, so that when it contains another type that is not supported, it will still process the supported cases. See this doc: https://developer.mozilla.org/en-US/docs/Web/API/CSSRule#Type_constants for the other types.
